### PR TITLE
[NO-JIRA] Remove workaround to include pom.xml instead of shaded pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,6 @@
   </organization>
 
   <properties>
-    <!-- Temporary workaround to force inclusion of pom.xml because of https://sonarsource.atlassian.net/browse/MSONAR-218 -->
-    <sonar.sources>.</sonar.sources>
-    <sonar.inclusions>pom.xml</sonar.inclusions>
-
     <!--
      This project contains some code from https://github.com/eclipse-jdt/eclipse.jdt.core with some minor changes.
      It does not match our code quality standard and can not be analyzed like other code in this repository.


### PR DESCRIPTION
Since the implementation of SCANMAVEN-218[0], we no longer need to force the inclusion of the original pom.xml file for the file to be indexed by the Maven scanner.

[0] https://sonarsource.atlassian.net/browse/SCANMAVEN-218