### PR TITLE
SONARJAVA-6236 Do not run nightly builds on weekends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "15 2 * * *" # Run daily at 2:15 AM UTC
+    - cron: "15 2 * * 1-5" # Run Mon-Fri at 2:15 AM UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -1,8 +1,8 @@
 name: Unified Dogfooding scans
 on:
   schedule:
-    # Run nightly at 2 AM UTC
-    - cron: '0 2 * * *'
+    # Run Mon-Fri at 2 AM UTC
+    - cron: '0 2 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Restrict scheduled workflow runs to weekdays (Mon-Fri) to avoid unnecessary weekend builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)