### PR TITLE
SONARJAVA-6316 Use semver range updates (not pinning) for SonarSource GitHub Actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,13 @@
     {
       // Manual update.
       matchPackageNames: [ "org.eclipse.jdt:org.eclipse.jdt.core" ],
-      enabled: false
+      enabled: false,
+    },
+    {
+      "description": "Use semver range updates (not pinning) for SonarSource GitHub Actions",
+      "matchManagers": [ "github-actions" ],
+      "matchPackagePatterns": [ "^SonarSource/" ],
+      "rangeStrategy": "replace"
     },
     {
       // Update quarterly to reduce number of PRs.

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,13 +5,13 @@
     {
       // Manual update.
       matchPackageNames: [ "org.eclipse.jdt:org.eclipse.jdt.core" ],
-      enabled: false,
+      enabled: false
     },
     {
-      "description": "Use semver range updates (not pinning) for SonarSource GitHub Actions",
-      "matchManagers": [ "github-actions" ],
-      "matchPackagePatterns": [ "^SonarSource/" ],
-      "rangeStrategy": "replace"
+      // Use semver range updates (not pinning) for SonarSource GitHub Actions 
+      matchManagers: [ "github-actions" ],
+      matchPackagePatterns: [ "^SonarSource/" ],
+      rangeStrategy: "replace"
     },
     {
       // Update quarterly to reduce number of PRs.


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate Configuration:**
  - Updated `renovate.json5` to enable semver range updates for `SonarSource` GitHub Actions using `rangeStrategy: "replace"`.

<sub>This will update automatically on new commits.</sub>