### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @SonarSource/quality-jvm-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Code ownership:**
  - Updated `.github/CODEOWNERS` to transition repository responsibility from `@SonarSource/quality-jvm-squad` to `@SonarSource/code-quality-core-languages-parsers-squad`.

<sub>This will update automatically on new commits.</sub>