### PR TITLE
CLP-27 Update release workflow to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,18 @@ name: sonar-release
 # This workflow is triggered when publishing a new github release
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Full version including build number, e.g. 1.2.3.456'
+        required: true
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       mavenCentralSync: true
       slackChannel: squad-jvm-notifs


### PR DESCRIPTION
Part of CLP-26
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Workflow configuration:**
  - Migrated `gh-action_release` version from `v6` to `v7` in `.github/workflows/release.yml`.
  - Replaced `release` trigger with `workflow_dispatch` to allow manual version input.

<sub>This will update automatically on new commits.</sub>