### PR TITLE
SONARJAVA-6486 Fix missing input for v7 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,6 @@ jobs:
       contents: write
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
+      version: ${{ inputs.version }}
       mavenCentralSync: true
       slackChannel: squad-jvm-notifs


### PR DESCRIPTION
Part of CLP-27
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **CI/CD Configuration:**
  - Added `version` input to the `release.yml` workflow to ensure compatibility with the `v7` release process.

<sub>This will update automatically on new commits.</sub>