### PR TITLE
CLP-100 Update notifications Slack channels

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: squad-jvm-notifs
+          slack-channel: squad-corelang-releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,4 @@ jobs:
     with:
       version: ${{ inputs.version }}
       mavenCentralSync: true
-      slackChannel: squad-jvm-notifs
+      slackChannel: squad-corelang-releases


### PR DESCRIPTION
Part of [CLP-59](https://sonarsource.atlassian.net/browse/CLP-59).

[CLP-59]: https://sonarsource.atlassian.net/browse/CLP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **CI/CD Configuration:**
  - Update Slack notification channels from `squad-jvm-notifs` to `squad-corelang-releases` in `ToggleLockBranch.yml` and `release.yml` workflows.

<sub>This will update automatically on new commits.</sub>