### PR TITLE
SONARJAVA-6294 Use squad Renovate preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,9 +1,98 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:quality-jvm-squad"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
   "packageRules": [
+    {
+      "description": "SonarSource GitHub actions do not need version pinning",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackagePatterns": [
+        "^SonarSource/"
+      ],
+      "matchUpdateTypes": [
+        "pin",
+        "rollback"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "gh-action_release uses branch-based versioning (v6, v7) which Renovate cannot resolve -- update manually",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "SonarSource/gh-action_release"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Parent POM should be updated separately",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.sonarsource.parent:parent",
+        "com.sonarsource.parent:parent"
+      ],
+      "groupName": "Parent",
+      "groupSlug": "parent"
+    },
+    {
+      "description": "Plugin API has compatibility rules, so disable it to prevent accidental updates",
+      "matchPackageNames": [
+        "org.sonarsource.api.plugin:sonar-plugin-api*"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "org.sonarsource.sonarlint.core*",
+        "org.sonarsource.sonarqube*"
+      ],
+      "groupName": "Sonar dependencies",
+      "groupSlug": "sonar-dependencies"
+    },
+    {
+      "matchPackageNames": [
+        "org.sonarsource.analyzer-commons*"
+      ],
+      "groupName": "Analyzer Commons",
+      "groupSlug": "analyzer-commons"
+    },
+    {
+      "matchPackageNames": [
+        "org.sonarsource.orchestrator*"
+      ],
+      "groupName": "Orchestrator",
+      "groupSlug": "orchestrator"
+    },
+    {
+      "matchPackageNames": [
+        "org.sonarsource.slang*"
+      ],
+      "groupName": "Slang",
+      "groupSlug": "slang"
+    },
+    {
+      "matchManagers": [
+        "gradle-wrapper"
+      ],
+      "matchPackageNames": [
+        "gradle"
+      ],
+      "groupName": "Gradle wrapper",
+      "groupSlug": "gradle-wrapper"
+    },
+    {
+      "matchPackageNames": [
+        "org.sonarqube:org.sonarqube.gradle.plugin"
+      ],
+      "groupName": "Sonar Gradle Plugin",
+      "groupSlug": "sonar-gradle-plugin"
+    },
     {
       "matchPackageNames": [
         "org.eclipse.jdt:org.eclipse.jdt.core"
@@ -27,5 +116,12 @@
         "schedule:quarterly"
       ]
     }
+  ],
+  "enabledManagers": [
+    "maven",
+    "gradle",
+    "gradle-wrapper",
+    "github-actions",
+    "regex"
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,121 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  extends: [ "local>SonarSource/core-languages-tooling-public:renovate-config" ],
-  addLabels: [ "dependencies" ],
-  rebaseWhen: "conflicted",
-  minimumReleaseAgeBehaviour: "timestamp-required",
-  enabledManagers: [ "maven", "gradle", "gradle-wrapper", "github-actions", "regex" ],
-  timezone: "Europe/Berlin",
-  schedule: [ "before 6am on Monday" ],
-  reviewers: [ "team:quality-jvm-squad" ],
-  packageRules: [
-    {
-      matchManagers: [ "regex" ],
-      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"
-    },
-    {
-      description: "Group GitHub Actions updates",
-      matchManagers: [ "github-actions" ],
-      groupName: "GitHub Actions dependencies",
-      groupSlug: "github-actions-dependencies"
-    },
-    {
-      description: "Group Maven updates",
-      matchManagers: [ "maven" ],
-      groupName: "Maven dependencies",
-      groupSlug: "maven-dependencies"
-    },
-    {
-      description: "Group Gradle updates",
-      matchManagers: [ "gradle", "gradle-wrapper" ],
-      groupName: "Gradle dependencies",
-      groupSlug: "gradle-dependencies"
-    },
-    {
-      description: "SonarSource GitHub actions do not need version pinning",
-      matchManagers: [ "github-actions" ],
-      matchPackagePatterns: [ "^SonarSource/" ],
-      matchUpdateTypes: [ "pin", "rollback" ],
-      enabled: false
-    },
-    {
-      description: "gh-action_release uses branch-based versioning (v6, v7) which Renovate cannot resolve -- update manually",
-      matchManagers: [ "github-actions" ],
-      matchPackageNames: [ "SonarSource/gh-action_release" ],
-      enabled: false
-    },
-    {
-      description: "Parent POM should be updated separately",
-      matchManagers: [ "maven" ],
-      matchPackageNames: [
-        "org.sonarsource.parent:parent",
-        "com.sonarsource.parent:parent"
-      ],
-      groupName: "Parent",
-      groupSlug: "parent"
-    },
-    {
-      description: "Plugin API has compatibility rules, so disable it to prevent accidental updates",
-      matchPackageNames: [ "org.sonarsource.api.plugin:sonar-plugin-api*" ],
-      enabled: false
-    },
-    {
-      matchPackageNames: [
-        "org.sonarsource.sonarlint.core*",
-        "org.sonarsource.sonarqube*"
-      ],
-      groupName: "Sonar dependencies",
-      groupSlug: "sonar-dependencies"
-    },
-    {
-      matchPackageNames: [ "org.sonarsource.analyzer-commons*" ],
-      groupName: "Analyzer Commons",
-      groupSlug: "analyzer-commons"
-    },
-    {
-      matchPackageNames: [ "org.sonarsource.orchestrator*" ],
-      groupName: "Orchestrator",
-      groupSlug: "orchestrator"
-    },
-    {
-      matchPackageNames: [ "org.sonarsource.slang*" ],
-      groupName: "Slang",
-      groupSlug: "slang"
-    },
-    {
-      matchManagers: [ "gradle-wrapper" ],
-      matchPackageNames: [ "gradle" ],
-      groupName: "Gradle wrapper",
-      groupSlug: "gradle-wrapper"
-    },
-    {
-      matchPackageNames: [ "org.sonarqube:org.sonarqube.gradle.plugin" ],
-      groupName: "Sonar Gradle Plugin",
-      groupSlug: "sonar-gradle-plugin"
-    },
-    {
-      // Manual update.
-      matchPackageNames: [ "org.eclipse.jdt:org.eclipse.jdt.core" ],
-      enabled: false
-    },
-    {
-      // Use semver range updates (not pinning) for SonarSource GitHub Actions
-      matchManagers: [ "github-actions" ],
-      matchPackagePatterns: [ "^SonarSource/" ],
-      rangeStrategy: "replace"
-    },
-    {
-      // Update quarterly to reduce number of PRs.
-      matchPaths: [ "build-eclipse-jdt-core-branch/**" ],
-      extends: [ "schedule:quarterly" ]
-    },
+  "extends": [
+    "local>SonarSource/core-languages-tooling-public:quality-jvm-squad"
   ],
-  regexManagers: [
+  "packageRules": [
     {
-      fileMatch: [ "^snapshot-generation.sh$" ],
-      matchStrings: [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\sexport .*?_VERSION=(?<currentValue>.*)\\s"
+      "matchPackageNames": [
+        "org.eclipse.jdt:org.eclipse.jdt.core"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackagePatterns": [
+        "^SonarSource/"
+      ],
+      "rangeStrategy": "replace"
+    },
+    {
+      "matchPaths": [
+        "build-eclipse-jdt-core-branch/**"
+      ],
+      "extends": [
+        "schedule:quarterly"
       ]
     }
-  ],
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,22 +1,121 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  extends: [ "github>SonarSource/renovate-config:quality-jvm-squad" ],
+  extends: [ "local>SonarSource/core-languages-tooling-public:renovate-config" ],
+  addLabels: [ "dependencies" ],
+  rebaseWhen: "conflicted",
+  minimumReleaseAgeBehaviour: "timestamp-required",
+  enabledManagers: [ "maven", "gradle", "gradle-wrapper", "github-actions", "regex" ],
+  timezone: "Europe/Berlin",
+  schedule: [ "before 6am on Monday" ],
+  reviewers: [ "team:quality-jvm-squad" ],
   packageRules: [
+    {
+      matchManagers: [ "regex" ],
+      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"
+    },
+    {
+      description: "Group GitHub Actions updates",
+      matchManagers: [ "github-actions" ],
+      groupName: "GitHub Actions dependencies",
+      groupSlug: "github-actions-dependencies"
+    },
+    {
+      description: "Group Maven updates",
+      matchManagers: [ "maven" ],
+      groupName: "Maven dependencies",
+      groupSlug: "maven-dependencies"
+    },
+    {
+      description: "Group Gradle updates",
+      matchManagers: [ "gradle", "gradle-wrapper" ],
+      groupName: "Gradle dependencies",
+      groupSlug: "gradle-dependencies"
+    },
+    {
+      description: "SonarSource GitHub actions do not need version pinning",
+      matchManagers: [ "github-actions" ],
+      matchPackagePatterns: [ "^SonarSource/" ],
+      matchUpdateTypes: [ "pin", "rollback" ],
+      enabled: false
+    },
+    {
+      description: "gh-action_release uses branch-based versioning (v6, v7) which Renovate cannot resolve -- update manually",
+      matchManagers: [ "github-actions" ],
+      matchPackageNames: [ "SonarSource/gh-action_release" ],
+      enabled: false
+    },
+    {
+      description: "Parent POM should be updated separately",
+      matchManagers: [ "maven" ],
+      matchPackageNames: [
+        "org.sonarsource.parent:parent",
+        "com.sonarsource.parent:parent"
+      ],
+      groupName: "Parent",
+      groupSlug: "parent"
+    },
+    {
+      description: "Plugin API has compatibility rules, so disable it to prevent accidental updates",
+      matchPackageNames: [ "org.sonarsource.api.plugin:sonar-plugin-api*" ],
+      enabled: false
+    },
+    {
+      matchPackageNames: [
+        "org.sonarsource.sonarlint.core*",
+        "org.sonarsource.sonarqube*"
+      ],
+      groupName: "Sonar dependencies",
+      groupSlug: "sonar-dependencies"
+    },
+    {
+      matchPackageNames: [ "org.sonarsource.analyzer-commons*" ],
+      groupName: "Analyzer Commons",
+      groupSlug: "analyzer-commons"
+    },
+    {
+      matchPackageNames: [ "org.sonarsource.orchestrator*" ],
+      groupName: "Orchestrator",
+      groupSlug: "orchestrator"
+    },
+    {
+      matchPackageNames: [ "org.sonarsource.slang*" ],
+      groupName: "Slang",
+      groupSlug: "slang"
+    },
+    {
+      matchManagers: [ "gradle-wrapper" ],
+      matchPackageNames: [ "gradle" ],
+      groupName: "Gradle wrapper",
+      groupSlug: "gradle-wrapper"
+    },
+    {
+      matchPackageNames: [ "org.sonarqube:org.sonarqube.gradle.plugin" ],
+      groupName: "Sonar Gradle Plugin",
+      groupSlug: "sonar-gradle-plugin"
+    },
     {
       // Manual update.
       matchPackageNames: [ "org.eclipse.jdt:org.eclipse.jdt.core" ],
       enabled: false
     },
     {
-      // Use semver range updates (not pinning) for SonarSource GitHub Actions 
+      // Use semver range updates (not pinning) for SonarSource GitHub Actions
       matchManagers: [ "github-actions" ],
       matchPackagePatterns: [ "^SonarSource/" ],
       rangeStrategy: "replace"
     },
     {
       // Update quarterly to reduce number of PRs.
-      matchPaths: [ "build-eclipse-jdt-core-branch/**"],
+      matchPaths: [ "build-eclipse-jdt-core-branch/**" ],
       extends: [ "schedule:quarterly" ]
     },
+  ],
+  regexManagers: [
+    {
+      fileMatch: [ "^snapshot-generation.sh$" ],
+      matchStrings: [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\sexport .*?_VERSION=(?<currentValue>.*)\\s"
+      ]
+    }
   ],
 }


### PR DESCRIPTION
## Summary
- switch this repository to the squad Renovate preset
- keep only repo-specific Renovate behavior in the repository

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- rebaseWhen: conflicted -> never
- minimumReleaseAgeBehaviour: timestamp-required -> timestamp-optional
- schedule: before 6am on Monday -> unset
- timezone: Europe/Berlin -> CET
- prCreation: not-pending -> immediate
- reviewers: team:quality-jvm-squad -> unset
- packageRules removed: {"matchManagers":["regex"],"versioning":"regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"}
- packageRules added: Don't group updates by default
- regexManagers: 1 -> 0
<!-- codex-effective-delta:end -->
