### PR TITLE
CLP-142 Clean up Renovate config in sonar-java-jdt

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,42 +5,6 @@
   ],
   "packageRules": [
     {
-      "description": "SonarSource GitHub actions do not need version pinning",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchPackageNames": [
-        "SonarSource/**"
-      ],
-      "matchUpdateTypes": [
-        "pin",
-        "rollback"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "gh-action_release uses branch-based versioning (v6, v7) which Renovate cannot resolve -- update manually",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchPackageNames": [
-        "SonarSource/gh-action_release"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Parent POM should be updated separately",
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "org.sonarsource.parent:parent",
-        "com.sonarsource.parent:parent"
-      ],
-      "groupName": "Parent",
-      "groupSlug": "parent"
-    },
-    {
       "description": "Plugin API has compatibility rules, so disable it to prevent accidental updates",
       "matchPackageNames": [
         "org.sonarsource.api.plugin:sonar-plugin-api*"
@@ -100,15 +64,6 @@
       "enabled": false
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchPackageNames": [
-        "SonarSource/**"
-      ],
-      "rangeStrategy": "replace"
-    },
-    {
       "matchFileNames": [
         "build-eclipse-jdt-core-branch/**"
       ],
@@ -116,11 +71,5 @@
         "schedule:quarterly"
       ]
     }
-  ],
-  "enabledManagers": [
-    "maven",
-    "gradle",
-    "gradle-wrapper",
-    "github-actions"
   ]
 }


### PR DESCRIPTION
Part of CLP-11.

This PR cleans up the local Renovate config after the latest updates in the squad parent preset.

Expected current effective delta:
- track `mise.toml` updates
